### PR TITLE
Minor clarification for casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ However, inline comments can be useful in certain scenarios:
 
 Use `camelCase` (with a leading lowercase character) to name all variables, methods, and object properties.
 
-Use `CamelCase` (with a leading uppercase character) to name all classes.
+Use `PascalCase` (with a leading uppercase character) to name all classes.
 
 _(The **official** CoffeeScript convention is camelcase, because this simplifies interoperability with JavaScript. For more on this decision, see [here][coffeescript-issue-425].)_
 


### PR DESCRIPTION
Great guide! Just one very minor nitpick: "camel case with a leading uppercase" is commonly referred to as "pascal case". Here's a tweak that represents that. :)
