### PR TITLE
fix contradictory example in Conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ Prefer single quoted strings (`''`) instead of double quoted (`""`) strings, unl
 <a name="conditionals"/>
 ## Conditionals
 
-Favor `unless` over `if` for negative conditions.
+Favor `if` over `unless` for negative conditions.
 
-Instead of using `unless...else`, use `if...else`:
+Use `if...else` rather than `unless...else`:
 
 ```coffeescript
   # Yes


### PR DESCRIPTION
The example in the Conditionals section shows that `if...else` should be preferred over `unless...else` for negative conditions. Yet the description above the example says the opposite.
This removes the contradiction so that `if...else` is preferred in both the description and the example.
