### PR TITLE
Setting the right anchor for extending_native_objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ object = one: 1, two: 2
 alert("#{key} = #{value}") for key, value of object
 ```
 
-<a name="#extending_native_objects"/>
+<a name="extending_native_objects"/>
 ## Extending Native Objects
 
 Do not modify native objects.


### PR DESCRIPTION
The link was a bit odd. It's just a one char delete.
