### PR TITLE
Avoid optional commas before newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,14 @@ bar:
   value: 87
 
 # No
-foo = ['some', 'string', 'values']
+foo = [
+  'some',
+  'string',
+  'values'
+]
 bar:
-  label: 'test', value: 87
+  label: 'test',
+  value: 87
 ```
 
 <a name="encoding"/>


### PR DESCRIPTION
This commit solves polarmobile/coffeescript-style-guide#23
