### PR TITLE
Remove parentheses in multi-line chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,10 @@ In cases where method calls are being chained and the code does not fit on a sin
 
 ```coffeescript
 [1..3]
-  .map((x) -> x * x)
-  .concat([10..12])
-  .filter((x) -> x < 11)
-  .reduce((x, y) -> x + y)
+  .map (x) -> x * x
+  .concat [10..12]
+  .filter (x) -> x < 11
+  .reduce (x, y) -> x + y
 ```
 
 When calling functions, choose to omit or include parentheses in such a way that optimizes for readability. Keeping in mind that "readability" can be subjective, the following examples demonstrate cases where parentheses have been omitted or included in a manner that the community deems to be optimal:


### PR DESCRIPTION
The style introduced in [CoffeeScript 1.7](http://coffeescript.org/#changelog) seems more natural and readable. Is that still controversial?

``` coffeescript
[1..3]
  .map (x) -> x * x
  .concat [10..12]
  .filter (x) -> x < 11
  .reduce (x, y) -> x + y
```
