### PR TITLE
update coffeelint.json according to the style guide

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,114 +1,135 @@
 {
+    "arrow_spacing": {
+        "level": "error"
+    },
+    "braces_spacing": {
+        "level": "error",
+        "spaces": 0,
+        "empty_object_spaces": 0
+    },
+    "camel_case_classes": {
+        "level": "error"
+    },
     "coffeescript_error": {
         "level": "error"
     },
-    "arrow_spacing": {
-        "name": "arrow_spacing",
-        "level": "warn"
-    },
-    "no_tabs": {
-        "name": "no_tabs",
-        "level": "error"
-    },
-    "no_trailing_whitespace": {
-        "name": "no_trailing_whitespace",
-        "level": "warn",
-        "allowed_in_comments": false,
-        "allowed_in_empty_lines": true
-    },
-    "max_line_length": {
-        "name": "max_line_length",
-        "value": 80,
-        "level": "warn",
-        "limitComments": true
-    },
-    "line_endings": {
-        "name": "line_endings",
-        "level": "ignore",
-        "value": "unix"
-    },
-    "no_trailing_semicolons": {
-        "name": "no_trailing_semicolons",
-        "level": "error"
-    },
-    "indentation": {
-        "name": "indentation",
-        "value": 2,
-        "level": "error"
-    },
-    "camel_case_classes": {
-        "name": "camel_case_classes",
-        "level": "error"
-    },
     "colon_assignment_spacing": {
-        "name": "colon_assignment_spacing",
-        "level": "warn",
+        "level": "error",
         "spacing": {
             "left": 0,
             "right": 1
         }
     },
-    "no_implicit_braces": {
-        "name": "no_implicit_braces",
-        "level": "ignore",
-        "strict": true
-    },
-    "no_plusplus": {
-        "name": "no_plusplus",
-        "level": "ignore"
-    },
-    "no_throwing_strings": {
-        "name": "no_throwing_strings",
-        "level": "error"
-    },
-    "no_backticks": {
-        "name": "no_backticks",
-        "level": "error"
-    },
-    "no_implicit_parens": {
-        "name": "no_implicit_parens",
-        "level": "ignore"
-    },
-    "no_empty_param_list": {
-        "name": "no_empty_param_list",
-        "level": "warn"
-    },
-    "no_stand_alone_at": {
-        "name": "no_stand_alone_at",
-        "level": "ignore"
-    },
-    "space_operators": {
-        "name": "space_operators",
-        "level": "warn"
-    },
-    "duplicate_key": {
-        "name": "duplicate_key",
-        "level": "error"
-    },
-    "empty_constructor_needs_parens": {
-        "name": "empty_constructor_needs_parens",
-        "level": "ignore"
-    },
     "cyclomatic_complexity": {
-        "name": "cyclomatic_complexity",
         "value": 10,
         "level": "ignore"
     },
-    "newlines_after_classes": {
-        "name": "newlines_after_classes",
-        "value": 3,
+    "duplicate_key": {
+        "level": "error"
+    },
+    "empty_constructor_needs_parens": {
         "level": "ignore"
     },
-    "no_unnecessary_fat_arrows": {
-        "name": "no_unnecessary_fat_arrows",
+    "ensure_comprehensions": {
         "level": "warn"
     },
+    "eol_last": {
+        "level": "error"
+    },
+    "indentation": {
+        "value": 2,
+        "level": "error"
+    },
+    "line_endings": {
+        "value": "unix",
+        "level": "error"
+    },
+    "max_line_length": {
+        "value": 79,
+        "level": "error",
+        "limitComments": true
+    },
     "missing_fat_arrows": {
-        "name": "missing_fat_arrows",
+        "level": "ignore",
+        "is_strict": false
+    },
+    "newlines_after_classes": {
+        "value": 1,
+        "level": "error"
+    },
+    "no_backticks": {
+        "level": "error"
+    },
+    "no_debugger": {
+        "level": "warn",
+        "console": false
+    },
+    "no_empty_functions": {
         "level": "ignore"
     },
-    "non_empty_constructor_needs_parens": {
-        "name": "non_empty_constructor_needs_parens",
+    "no_empty_param_list": {
+        "level": "error"
+    },
+    "no_implicit_braces": {
+        "level": "ignore",
+        "strict": true
+    },
+    "no_implicit_parens": {
+        "strict": true,
         "level": "ignore"
+    },
+    "no_interpolation_in_single_quotes": {
+        "level": "error"
+    },
+    "no_nested_string_interpolation": {
+        "level": "warn"
+    },
+    "no_plusplus": {
+        "level": "ignore"
+    },
+    "no_private_function_fat_arrows": {
+        "level": "warn"
+    },
+    "no_stand_alone_at": {
+        "level": "error"
+    },
+    "no_tabs": {
+        "level": "error"
+    },
+    "no_this": {
+        "level": "error"
+    },
+    "no_throwing_strings": {
+        "level": "error"
+    },
+    "no_trailing_semicolons": {
+        "level": "error"
+    },
+    "no_trailing_whitespace": {
+        "level": "error",
+        "allowed_in_comments": false,
+        "allowed_in_empty_lines": true
+    },
+    "no_unnecessary_double_quotes": {
+        "level": "error"
+    },
+    "no_unnecessary_fat_arrows": {
+        "level": "warn"
+    },
+    "non_empty_constructor_needs_parens": {
+        "level": "ignore"
+    },
+    "prefer_english_operator": {
+        "level": "error",
+        "doubleNotLevel": "ignore"
+    },
+    "space_operators": {
+        "level": "error"
+    },
+    "spacing_after_comma": {
+        "level": "error"
+    },
+    "transform_messes_up_line_numbers": {
+        "level": "warn"
     }
 }


### PR DESCRIPTION
`coffeelint.json` not update for a long time~

I update this file based on [coffeelint default configure](https://github.com/clutchski/coffeelint/blob/master/generated_coffeelint.json), and update some specific rule according to the code style guide~

Below list the difference comparing with [coffeelint default configure](https://github.com/clutchski/coffeelint/blob/master/generated_coffeelint.json):
### arrow_spacing

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#functions
### max_line_length

level: `error`  
description: limit all lines to a maximum of 79 characters.  
refer: https://github.com/polarmobile/coffeescript-style-guide#maximum-line-length
### newlines_after_classes

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#blank-lines
### no_empty_param_list

level: `error`
refer: https://github.com/polarmobile/coffeescript-style-guide#functions
### no_interpolation_in_single_quotes

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#strings
### no_stand_alone_at

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#miscellaneous
### no_this

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#miscellaneous
### no_unnecessary_double_quotes

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#strings
### prefer_english_operator

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#miscellaneous
### space_operators

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#whitespace
### spacing_after_comma

level: `error`  
refer: https://github.com/polarmobile/coffeescript-style-guide#whitespace
### braces_spacing

`{a: 5}` prefered instead of `{ a: 5 }`
### colon_assignment_spacing

level: `error`  
description: no space before `:` and a single space after `:`
### eol_last

level: `error`  
description:  file should ends with a single newline.
### line_endings

level: `error`  
description: unix like line ending
